### PR TITLE
Add aspect ratio option for dual stream DINO encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Currently, `qwen-vl-utils` supports three video decoding backends: `torchvision`
 
 - To use `torchcodec` as the backend for video decoding, follow the installation instructions provided in the official [torchcodec repository](https://github.com/pytorch/torchcodec/tree/main?tab=readme-ov-file#installing-torchcodec) and install it manually. Note that `torchcodec` depends on FFmpeg for decoding functionality.
 
+- For the dual-stream high-fidelity encoder, `DualStreamConfig` now exposes a `dinov3_keep_aspect_ratio` flag. When set to `True`, the resize step preserves the original aspect ratio by scaling the longer side to `dinov3_image_size` and adjusting the shorter side proportionally with anti-aliasing enabled. Enable this option—or provide higher resolution inputs—when you need to maximise small-detail preservation (for example, microscopic text or intricate diagrams).
+
 ## Cookbooks
 
 We are preparing [cookbooks](https://github.com/QwenLM/Qwen2.5-VL/tree/main/cookbooks) for many capabilities, including recognition, localization, document parsing, video understanding, key information extraction, and more. Welcome to learn more!

--- a/qwen-vl-utils/src/qwen_vl_utils/__init__.py
+++ b/qwen-vl-utils/src/qwen_vl_utils/__init__.py
@@ -5,3 +5,14 @@ from .vision_process import (
     process_vision_info,
     smart_resize,
 )
+from .dual_stream import DualStreamConfig, DualStreamEncoder
+
+__all__ = [
+    "extract_vision_info",
+    "fetch_image",
+    "fetch_video",
+    "process_vision_info",
+    "smart_resize",
+    "DualStreamConfig",
+    "DualStreamEncoder",
+]

--- a/qwen-vl-utils/src/qwen_vl_utils/dual_stream.py
+++ b/qwen-vl-utils/src/qwen_vl_utils/dual_stream.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import torch
+from PIL import Image
+from torchvision.transforms import InterpolationMode
+from torchvision.transforms import functional as F
+
+
+@dataclass
+class DualStreamConfig:
+    """Configuration container for :class:`DualStreamEncoder`."""
+
+    dinov3_image_size: int = 336
+    """Target resolution for the longer side of each image."""
+
+    dinov3_keep_aspect_ratio: bool = False
+    """Whether to keep the input aspect ratio when resizing for DINOv3."""
+
+    dinov3_mean: Sequence[float] = (0.485, 0.456, 0.406)
+    dinov3_std: Sequence[float] = (0.229, 0.224, 0.225)
+    dinov3_interpolation: InterpolationMode = InterpolationMode.BICUBIC
+    device: torch.device | str = "cpu"
+    dtype: torch.dtype = torch.float32
+
+
+class DualStreamEncoder:
+    """Utility to encode images for the dual-stream inference pipeline."""
+
+    def __init__(
+        self,
+        config: DualStreamConfig,
+        dinov3_model: torch.nn.Module | None = None,
+    ) -> None:
+        self.config = config
+        self.dinov3_model = dinov3_model
+        if self.dinov3_model is not None:
+            self.dinov3_model.to(self.config.device, dtype=self.config.dtype)
+            self.dinov3_model.eval()
+
+    def _resize_for_high_fidelity(self, image: Image.Image) -> Image.Image:
+        """Resize the input image following the configuration policy."""
+
+        longer_side = self.config.dinov3_image_size
+        width, height = image.size
+
+        if self.config.dinov3_keep_aspect_ratio:
+            if height >= width:
+                new_height = longer_side
+                new_width = max(1, round(width * longer_side / max(height, 1)))
+            else:
+                new_width = longer_side
+                new_height = max(1, round(height * longer_side / max(width, 1)))
+            size = (new_height, new_width)
+        else:
+            size = (longer_side, longer_side)
+
+        return F.resize(image, size, interpolation=self.config.dinov3_interpolation, antialias=True)
+
+    def _preprocess_high_fidelity(self, image: Image.Image) -> torch.Tensor:
+        resized = self._resize_for_high_fidelity(image.convert("RGB"))
+        tensor = F.to_tensor(resized)
+        return F.normalize(tensor, self.config.dinov3_mean, self.config.dinov3_std)
+
+    def _encode_high_fidelity(self, images: Iterable[Image.Image]) -> torch.Tensor:
+        """Encode a collection of images using the high-fidelity DINOv3 branch."""
+
+        batch = torch.stack([self._preprocess_high_fidelity(img) for img in images])
+        batch = batch.to(self.config.device, dtype=self.config.dtype)
+
+        if self.dinov3_model is None:
+            return batch
+
+        with torch.no_grad():
+            features = self.dinov3_model(batch)
+        return features
+
+
+__all__ = ["DualStreamConfig", "DualStreamEncoder"]


### PR DESCRIPTION
## Summary
- add a DualStreamEncoder helper and expose the new dinov3_keep_aspect_ratio flag so long-edge resizing can preserve aspect ratios with anti-aliasing
- export the dual stream utilities through the qwen_vl_utils namespace
- document the new flag in the README so users know to enable it when prioritising fine details

## Testing
- python -m compileall qwen-vl-utils/src/qwen_vl_utils/dual_stream.py

------
https://chatgpt.com/codex/tasks/task_e_68ccbac0c9488329b35a8a95663c45fc