### PR TITLE
Unfreeze dual-stream DINO branch by default

### DIFF
--- a/qwen-vl-finetune/README.md
+++ b/qwen-vl-finetune/README.md
@@ -309,3 +309,9 @@ The script accepts arguments in three categories:
    - Training with Qwen2.5-VL-32B model, you should have 8 80G GPU refering to `scripts/sft_32b.sh`
    - `"_attn_implementation": "flash_attention_2",` could be add in the config.json of the model to use flash attention.
 
+### Dual-Stream Training
+
+当使用双流视觉编码器时，CLI 现在默认会解冻高保真（DINO）分支，以便模型在工业场景下自动完成领域适配。如果希望继续保持该分支冻结，可显式传入 `--dual_stream_freeze_high_fidelity_stream true`。
+
+When training with the dual-stream vision encoder, the CLI now leaves the high-fidelity (DINO) stream unfrozen so it can adapt to domain-specific data out of the box. Pass `--dual_stream_freeze_high_fidelity_stream true` if you prefer to keep the DINO branch frozen.
+

--- a/qwen-vl-finetune/qwenvl/models/__init__.py
+++ b/qwen-vl-finetune/qwenvl/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model configuration helpers for QwenVL training."""
+
+from .dual_stream_config import DualStreamConfig
+
+__all__ = ["DualStreamConfig"]

--- a/qwen-vl-finetune/qwenvl/models/dual_stream_config.py
+++ b/qwen-vl-finetune/qwenvl/models/dual_stream_config.py
@@ -1,0 +1,29 @@
+"""Configuration dataclasses for dual-stream vision encoders."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class DualStreamConfig:
+    """Configuration for the dual-stream visual encoder.
+
+    Attributes:
+        freeze_high_fidelity_stream: Whether to keep the high-fidelity stream (DINO branch)
+            frozen. Set this to ``False`` (the default) to let the branch adapt to the target
+            domain during fine-tuning. We recommend unfreezing it in industrial scenarios so the
+            DINO stream can learn domain-specific features.
+    """
+
+    freeze_high_fidelity_stream: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to freeze the high-fidelity (DINO) stream. We recommend leaving this "
+                "stream unfrozen in industrial fine-tuning so it can adapt to domain-specific "
+                "data."
+            )
+        },
+    )
+
+
+__all__ = ["DualStreamConfig"]

--- a/qwen-vl-finetune/qwenvl/train/argument.py
+++ b/qwen-vl-finetune/qwenvl/train/argument.py
@@ -25,6 +25,20 @@ class DataArguments:
 
 
 @dataclass
+class DualStreamArguments:
+    freeze_high_fidelity_stream: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to freeze the high-fidelity (DINO) stream when using the dual-stream "
+                "vision encoder. Defaults to False so the DINO branch is unfrozen and can adapt "
+                "to industrial scenarios. Set to true to keep the branch frozen."
+            )
+        },
+    )
+
+
+@dataclass
 class TrainingArguments(transformers.TrainingArguments):
     cache_dir: Optional[str] = field(default=None)
     optim: str = field(default="adamw_torch")

--- a/qwen-vl-finetune/qwenvl/train/train_qwen.py
+++ b/qwen-vl-finetune/qwenvl/train/train_qwen.py
@@ -37,10 +37,12 @@ from transformers import (
 )
 from qwenvl.data.data_qwen import make_supervised_data_module
 from qwenvl.data.data_qwen_packed import make_supervised_data_module_packed
+from qwenvl.models.dual_stream_config import DualStreamConfig
 from qwenvl.train.argument import (
     ModelArguments,
     DataArguments,
     TrainingArguments,
+    DualStreamArguments,
 )
 from transformers import AutoTokenizer, AutoProcessor, Qwen2VLImageProcessor, Trainer
 
@@ -96,9 +98,19 @@ def train(attn_implementation="flash_attention_2"):
     global local_rank
 
     parser = transformers.HfArgumentParser(
-        (ModelArguments, DataArguments, TrainingArguments)
+        (ModelArguments, DataArguments, TrainingArguments, DualStreamArguments)
     )
-    model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+    (
+        model_args,
+        data_args,
+        training_args,
+        dual_stream_args,
+    ) = parser.parse_args_into_dataclasses()
+
+    dual_stream_config = DualStreamConfig(
+        freeze_high_fidelity_stream=dual_stream_args.freeze_high_fidelity_stream
+    )
+    model_args.dual_stream_config = dual_stream_config
 
     local_rank = training_args.local_rank
     os.makedirs(training_args.output_dir, exist_ok=True)


### PR DESCRIPTION
## Summary
- add a dedicated dual-stream configuration module with freeze_high_fidelity_stream defaulting to False and guidance for industrial fine-tuning
- align DualStreamArguments defaults/help text and wire the parser to surface the new CLI behaviour
- document the new default and override flag in the dual-stream training section of the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccb5d53f4c8329bbf3279c6c821ac2