### PR TITLE
Support loading DINOv3 from ModelScope

### DIFF
--- a/qwen-vl-finetune/qwenvl/models/__init__.py
+++ b/qwen-vl-finetune/qwenvl/models/__init__.py
@@ -1,0 +1,18 @@
+"""Custom multimodal modules for Qwen2.5-VL extensions."""
+
+from .dual_stream_config import DualStreamConfig
+from .dual_stream_encoder import DualStreamVisionEncoder, DualStreamVisionOutput
+from .ve_gate import VisualEvidenceGate
+from .dual_stream_model import (
+    DualStreamQwen25VLModel,
+    Qwen2_5_VLDualStreamForConditionalGeneration,
+)
+
+__all__ = [
+    "DualStreamConfig",
+    "DualStreamVisionEncoder",
+    "DualStreamVisionOutput",
+    "VisualEvidenceGate",
+    "DualStreamQwen25VLModel",
+    "Qwen2_5_VLDualStreamForConditionalGeneration",
+]

--- a/qwen-vl-finetune/qwenvl/models/dual_stream_config.py
+++ b/qwen-vl-finetune/qwenvl/models/dual_stream_config.py
@@ -1,0 +1,75 @@
+"""Configuration dataclass for the dual-stream visual encoder stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict
+
+
+@dataclass
+class DualStreamConfig:
+    """Holds hyper-parameters for the dual-stream vision encoder and VE-Gate.
+
+    Attributes:
+        dinov3_modelscope_model_id: Optional ModelScope model or directory that
+            should be loaded via :func:`modelscope.AutoModel.from_pretrained`.
+            When provided the ModelScope implementation is preferred over
+            Torch Hub.
+        dinov3_modelscope_revision: Optional revision identifier passed to
+            ModelScope when ``dinov3_modelscope_model_id`` references a remote
+            model.
+        dinov3_modelscope_device_map: Optional device map forwarded to
+            :func:`AutoModel.from_pretrained` so the ModelScope model can be
+            loaded on a specific device (e.g. ``"auto"``).
+        dinov3_modelscope_trust_remote_code: Whether to enable
+            ``trust_remote_code`` when initialising the ModelScope checkpoint.
+        dinov3_repo_or_dir: Torch Hub repository or local directory hosting the
+            DINOv3 implementation. Defaults to the official
+            ``facebookresearch/dinov3`` repo. Only used when the ModelScope
+            configuration is absent or fails.
+        dinov3_model_name: Name of the high-fidelity vision backbone that will
+            be instantiated via :func:`torch.hub.load` as a fallback.
+        dinov3_checkpoint_path: Optional checkpoint file or directory containing
+            weights for the DINOv3 backbone. When ``None`` the pretrained weights
+            bundled with ``dinov3_repo_or_dir`` will be downloaded automatically.
+        dinov3_image_size: Input spatial resolution expected by the DINOv3
+            backbone. Input images will be resized to this square resolution
+            before being fed to the high-fidelity encoder.
+        freeze_semantic_stream: If ``True`` the original Qwen2.5-VL vision tower
+            is frozen during training.
+        freeze_high_fidelity_stream: If ``True`` the DINOv3 branch is kept
+            frozen during training.
+        fusion_hidden_ratio: Multiplicative factor controlling the hidden size
+            of the fusion MLP. A value of ``2.0`` doubles the hidden size.
+        fusion_dropout: Dropout probability applied inside the fusion MLP.
+        ve_gate_hidden_ratio: Reduction ratio used by the VE-Gate MLP. Larger
+            values make the gating network smaller.
+        ve_gate_dropout: Dropout probability inside the VE-Gate MLP.
+        ve_gate_temperature: Initial temperature used to sharpen or smooth the
+            gating sigmoid. The parameter is learned during training but can be
+            initialised here.
+    """
+
+    dinov3_modelscope_model_id: str | None = None
+    dinov3_modelscope_revision: str | None = None
+    dinov3_modelscope_device_map: str | None = None
+    dinov3_modelscope_trust_remote_code: bool = True
+    dinov3_repo_or_dir: str = "facebookresearch/dinov3"
+    dinov3_model_name: str = "dinov3_vith16plus"
+    dinov3_checkpoint_path: str | None = None
+    dinov3_image_size: int = 518
+    freeze_semantic_stream: bool = False
+    freeze_high_fidelity_stream: bool = True
+    fusion_hidden_ratio: float = 2.0
+    fusion_dropout: float = 0.1
+    ve_gate_hidden_ratio: int = 4
+    ve_gate_dropout: float = 0.1
+    ve_gate_temperature: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the configuration into a serialisable dictionary."""
+
+        return asdict(self)
+
+
+__all__ = ["DualStreamConfig"]

--- a/qwen-vl-finetune/qwenvl/models/dual_stream_encoder.py
+++ b/qwen-vl-finetune/qwenvl/models/dual_stream_encoder.py
@@ -1,0 +1,440 @@
+"""Dual-stream visual encoder that augments Qwen2.5-VL with a DINOv3 branch."""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+try:  # pragma: no cover - optional dependency during linting
+    import timm
+except ImportError as exc:  # pragma: no cover
+    timm = None
+    _TIMM_IMPORT_ERROR = exc
+else:  # pragma: no cover
+    _TIMM_IMPORT_ERROR = None
+
+try:  # pragma: no cover - optional dependency during linting
+    from modelscope import AutoModel
+except ImportError as exc:  # pragma: no cover
+    AutoModel = None
+    _MODELSCOPE_IMPORT_ERROR = exc
+else:  # pragma: no cover
+    _MODELSCOPE_IMPORT_ERROR = None
+
+from .dual_stream_config import DualStreamConfig
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class DualStreamVisionOutput:
+    """Container returned by :class:`DualStreamVisionEncoder`.
+
+    Attributes:
+        semantic: List of tensors produced by the original Qwen2.5-VL vision
+            tower. Each tensor corresponds to a different image placeholder and
+            has shape ``(num_tokens, hidden_size)``.
+        high_fidelity: List of tensors containing the projected DINOv3 features
+            that are aligned with the semantic stream.
+        fused: List of tensors that result from fusing the semantic and
+            high-fidelity streams.
+    """
+
+    semantic: List[torch.Tensor]
+    high_fidelity: List[torch.Tensor]
+    fused: List[torch.Tensor]
+
+    def flatten(self, attr: str) -> torch.Tensor:
+        """Concatenate a list attribute into a single tensor."""
+
+        tensors: Sequence[torch.Tensor] = getattr(self, attr)
+        if not tensors:
+            raise ValueError(f"Attribute '{attr}' is empty and cannot be flattened.")
+        return torch.cat(tensors, dim=0)
+
+
+class DualStreamVisionEncoder(nn.Module):
+    """Wraps Qwen2.5-VL's vision tower with a high-fidelity DINOv3 branch.
+
+    The encoder keeps the original Qwen tower for semantic alignment while a
+    second DINOv3 stream preserves rich geometric and textural cues. Both
+    streams are fused through a learnable MLP and exposed via
+    :class:`DualStreamVisionOutput`.
+    """
+
+    def __init__(self, semantic_encoder: nn.Module, config: DualStreamConfig):
+        super().__init__()
+
+        self.semantic_encoder = semantic_encoder
+        self.config = config
+
+        self.hidden_size = getattr(semantic_encoder.config, "hidden_size", None)
+        if self.hidden_size is None:
+            raise AttributeError("semantic_encoder.config.hidden_size must be defined")
+
+        self.spatial_merge_size = getattr(semantic_encoder, "spatial_merge_size", 1)
+
+        checkpoint_path = self._resolve_checkpoint(config.dinov3_checkpoint_path)
+        self.high_fidelity_encoder = self._build_high_fidelity_encoder(
+            config, checkpoint_path
+        )
+        if checkpoint_path:
+            LOGGER.info("Loaded DINOv3 weights from %s", checkpoint_path)
+        if hasattr(self.high_fidelity_encoder, "reset_classifier"):
+            self.high_fidelity_encoder.reset_classifier(0)
+
+        self.high_dim = getattr(self.high_fidelity_encoder, "num_features", None)
+        if self.high_dim is None:
+            self.high_dim = getattr(self.high_fidelity_encoder, "embed_dim", None)
+        if self.high_dim is None:
+            raise AttributeError("Could not infer hidden size of the DINOv3 encoder")
+
+        patch_size = getattr(self.high_fidelity_encoder.patch_embed, "patch_size", None)
+        if patch_size is None:
+            raise AttributeError("DINOv3 encoder must expose patch_embed.patch_size")
+        self.register_buffer(
+            "high_patch_size",
+            torch.tensor(patch_size if isinstance(patch_size, Iterable) else (patch_size, patch_size), dtype=torch.long),
+            persistent=False,
+        )
+        self.base_num_patches = getattr(
+            self.high_fidelity_encoder.patch_embed, "num_patches", None
+        )
+        self.has_cls_token = hasattr(self.high_fidelity_encoder, "cls_token")
+
+        fusion_hidden = int(self.hidden_size * config.fusion_hidden_ratio)
+        self.high_proj = nn.Linear(self.high_dim, self.hidden_size, bias=False)
+        self.fusion_mlp = nn.Sequential(
+            nn.LayerNorm(self.hidden_size * 2),
+            nn.Linear(self.hidden_size * 2, fusion_hidden),
+            nn.SiLU(),
+            nn.Dropout(config.fusion_dropout),
+            nn.Linear(fusion_hidden, self.hidden_size),
+        )
+        self.fusion_norm = nn.LayerNorm(self.hidden_size)
+
+        if config.freeze_high_fidelity_stream:
+            for param in self.high_fidelity_encoder.parameters():
+                param.requires_grad = False
+            self.high_fidelity_encoder.eval()
+        if config.freeze_semantic_stream:
+            for param in self.semantic_encoder.parameters():
+                param.requires_grad = False
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.parameters()).device
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        image_grid_thw: Optional[torch.LongTensor],
+    ) -> DualStreamVisionOutput:
+        if image_grid_thw is None:
+            raise ValueError("image_grid_thw must be provided for dual-stream encoding")
+
+        split_sizes = self._compute_split_sizes(image_grid_thw)
+        target_hw = self._target_hw(image_grid_thw)
+
+        # Extract high-fidelity features before the semantic stream touches the
+        # pixels so that DINOv3 always sees the raw image tensor without the
+        # preprocessing side effects introduced by the original vision tower.
+        high_chunks_raw = self._encode_high_fidelity(pixel_values, target_hw)
+        high_chunks = [self.high_proj(chunk) for chunk in high_chunks_raw]
+
+        semantic_tokens = self.semantic_encoder(pixel_values, grid_thw=image_grid_thw)
+        semantic_chunks = list(torch.split(semantic_tokens, split_sizes))
+
+        fused_chunks = []
+        for semantic, high in zip(semantic_chunks, high_chunks):
+            fusion_input = torch.cat([semantic, high], dim=-1)
+            fused = self.fusion_mlp(fusion_input)
+            fused = self.fusion_norm(fused + semantic)
+            fused_chunks.append(fused)
+
+        return DualStreamVisionOutput(
+            semantic=semantic_chunks, high_fidelity=high_chunks, fused=fused_chunks
+        )
+
+    # ------------------------------------------------------------------
+    # Helper utilities
+    # ------------------------------------------------------------------
+    def _build_high_fidelity_encoder(
+        self, config: DualStreamConfig, checkpoint_path: Optional[str]
+    ) -> nn.Module:
+        """Instantiate the high-fidelity branch with ModelScope or fall back to Torch Hub."""
+
+        modelscope_encoder = self._try_build_modelscope_encoder(config)
+        if modelscope_encoder is not None:
+            LOGGER.info(
+                "Initialised DINOv3 encoder from ModelScope target '%s'",
+                config.dinov3_modelscope_model_id,
+            )
+            return modelscope_encoder
+
+        hub_kwargs = dict(
+            repo_or_dir=config.dinov3_repo_or_dir,
+            model=config.dinov3_model_name,
+            pretrained=checkpoint_path is None,
+        )
+        if checkpoint_path is not None:
+            hub_kwargs["weights"] = checkpoint_path
+
+        try:
+            encoder = torch.hub.load(**hub_kwargs)
+            LOGGER.info(
+                "Initialised DINOv3 encoder %s from %s",
+                config.dinov3_model_name,
+                config.dinov3_repo_or_dir,
+            )
+            return encoder
+        except Exception as hub_error:  # pragma: no cover - defensive fallback
+            if timm is None:
+                raise RuntimeError(
+                    "torch.hub.load failed and timm is unavailable to build the DINOv3 encoder"
+                ) from hub_error
+
+            LOGGER.warning(
+                "torch.hub.load failed for %s (repo %s): %s. Falling back to timm.",
+                config.dinov3_model_name,
+                config.dinov3_repo_or_dir,
+                hub_error,
+            )
+            return timm.create_model(
+                config.dinov3_model_name,
+                pretrained=checkpoint_path is None,
+                checkpoint_path=checkpoint_path or "",
+            )
+
+    def _try_build_modelscope_encoder(
+        self, config: DualStreamConfig
+    ) -> Optional[nn.Module]:  # pragma: no cover - network/environment dependent
+        if not config.dinov3_modelscope_model_id:
+            return None
+
+        if AutoModel is None:
+            LOGGER.warning(
+                "ModelScope is not available (import error: %s). Falling back to torch.hub.",
+                _MODELSCOPE_IMPORT_ERROR,
+            )
+            return None
+
+        load_target = config.dinov3_modelscope_model_id
+        load_kwargs = {
+            "trust_remote_code": config.dinov3_modelscope_trust_remote_code,
+        }
+        if config.dinov3_modelscope_revision:
+            load_kwargs["revision"] = config.dinov3_modelscope_revision
+        if config.dinov3_modelscope_device_map:
+            load_kwargs["device_map"] = config.dinov3_modelscope_device_map
+
+        try:
+            encoder = AutoModel.from_pretrained(load_target, **load_kwargs)
+        except Exception as exc:
+            LOGGER.warning(
+                "Failed to load DINOv3 via ModelScope target '%s': %s. Falling back to torch.hub.",
+                load_target,
+                exc,
+            )
+            return None
+
+        unwrapped = self._unwrap_modelscope_model(encoder)
+        if unwrapped is None:
+            LOGGER.warning(
+                "ModelScope model '%s' did not expose a usable encoder. Falling back to torch.hub.",
+                load_target,
+            )
+            return None
+
+        return unwrapped
+
+    def _compute_split_sizes(self, image_grid_thw: torch.LongTensor) -> List[int]:
+        merge_sq = self.spatial_merge_size ** 2
+        split_sizes = (image_grid_thw.prod(-1) // merge_sq).tolist()
+        if any(size <= 0 for size in split_sizes):
+            raise ValueError(
+                "image_grid_thw produced non-positive split sizes. Check preprocessing."
+            )
+        return split_sizes
+
+    def _target_hw(self, image_grid_thw: torch.LongTensor) -> List[Tuple[int, int]]:
+        target_hw = []
+        merge = self.spatial_merge_size
+        for grid in image_grid_thw.tolist():
+            _, h, w = grid
+            target_hw.append((max(1, h // merge), max(1, w // merge)))
+        return target_hw
+
+    def _resolve_checkpoint(self, user_path: Optional[str]) -> Optional[str]:
+        if user_path is None:
+            return None
+
+        path = Path(user_path).expanduser()
+        if path.is_file():
+            return str(path)
+
+        if path.is_dir():
+            preferred = (
+                "model.safetensors",
+                "pytorch_model.bin",
+                "model.pt",
+                "model.pth",
+                "checkpoint.pth",
+                "weights.pt",
+                "weights.pth",
+            )
+            for name in preferred:
+                candidate = path / name
+                if candidate.exists():
+                    return str(candidate)
+
+            # Fall back to the first checkpoint-like file we can find.
+            for suffix in ("*.safetensors", "*.bin", "*.pt", "*.pth"):
+                matches = sorted(path.glob(suffix))
+                if matches:
+                    return str(matches[0])
+
+            raise FileNotFoundError(
+                f"Could not find a checkpoint file in directory '{path}'."
+            )
+
+        raise FileNotFoundError(f"Provided DINOv3 checkpoint path '{path}' is invalid")
+
+    def _unwrap_modelscope_model(self, encoder: nn.Module) -> Optional[nn.Module]:
+        if not isinstance(encoder, nn.Module):
+            return None
+
+        queue: List[nn.Module] = [encoder]
+        visited = {id(encoder)}
+        fallback: Optional[nn.Module] = None
+
+        while queue:
+            candidate = queue.pop(0)
+
+            if self._has_implemented_method(candidate, "forward_features"):
+                return candidate
+
+            if self._has_implemented_method(candidate, "forward") and fallback is None:
+                fallback = candidate
+
+            for attr in ("model", "module", "backbone", "encoder", "net"):
+                child = getattr(candidate, attr, None)
+                if isinstance(child, nn.Module) and id(child) not in visited:
+                    visited.add(id(child))
+                    queue.append(child)
+
+        return fallback
+
+    @staticmethod
+    def _has_implemented_method(module: nn.Module, name: str) -> bool:
+        if not hasattr(module, name):
+            return False
+
+        method = getattr(module, name)
+        if not callable(method):
+            return False
+
+        base = getattr(nn.Module, name, None)
+        return getattr(type(module), name, None) is not base
+
+    def _encode_high_fidelity(
+        self,
+        pixel_values: torch.Tensor,
+        target_hw: Sequence[Tuple[int, int]],
+    ) -> List[torch.Tensor]:
+        resize_size = (self.config.dinov3_image_size, self.config.dinov3_image_size)
+        inputs = F.interpolate(
+            pixel_values.float(), size=resize_size, mode="bicubic", align_corners=False
+        )
+        features = self._forward_high_fidelity_features(inputs)
+        tokens = self._extract_patch_tokens(features)
+        batch, length, channels = tokens.shape
+        grid_h = int(round(math.sqrt(length)))
+        grid_w = grid_h
+        if grid_h * grid_w != length:
+            if grid_h == 0:
+                raise ValueError("DINOv3 produced zero patch tokens")
+            grid_w = length // grid_h
+            if grid_h * grid_w != length:
+                raise ValueError(
+                    "DINOv3 patch tokens cannot be reshaped into a 2D grid"
+                )
+        tokens = tokens.transpose(1, 2).reshape(batch, channels, grid_h, grid_w)
+
+        outputs: List[torch.Tensor] = []
+        for idx, (target_h, target_w) in enumerate(target_hw):
+            resized = F.interpolate(
+                tokens[idx : idx + 1], size=(target_h, target_w), mode="bicubic", align_corners=False
+            )
+            outputs.append(resized.flatten(2).transpose(1, 2).squeeze(0))
+        return outputs
+
+    def _forward_high_fidelity_features(self, inputs: torch.Tensor):
+        encoder = self.high_fidelity_encoder
+
+        if hasattr(encoder, "forward_features") and callable(getattr(encoder, "forward_features")):
+            return encoder.forward_features(inputs)
+
+        try:
+            return encoder(pixel_values=inputs)
+        except TypeError:
+            try:
+                return encoder(inputs)
+            except TypeError as exc:
+                raise TypeError(
+                    "High-fidelity encoder does not accept 'pixel_values' or positional inputs"
+                ) from exc
+
+    def _extract_patch_tokens(self, features: torch.Tensor | dict) -> torch.Tensor:
+        if hasattr(features, "last_hidden_state"):
+            features = features.last_hidden_state
+        elif hasattr(features, "token_embeddings"):
+            features = features.token_embeddings
+
+        if isinstance(features, (list, tuple)) and features:
+            features = features[0]
+
+        if isinstance(features, dict):
+            for key in (
+                "x_norm_patchtokens",
+                "token_embeddings",
+                "last_hidden_state",
+                "x_norm_clstoken",
+            ):
+                if key in features:
+                    features = features[key]
+                    break
+            else:  # pragma: no cover - defensive branch
+                raise KeyError("Unsupported DINOv3 forward_features output format")
+
+        if not isinstance(features, torch.Tensor):
+            raise TypeError(
+                "High-fidelity encoder produced an output that could not be converted to a tensor"
+            )
+
+        if features.ndim != 3:
+            raise ValueError("Expected features with shape (batch, tokens, dim)")
+
+        if self.has_cls_token and features.shape[1] > 0:
+            total_tokens = features.shape[1]
+            if (
+                self.base_num_patches is not None
+                and total_tokens == self.base_num_patches + 1
+            ):
+                features = features[:, 1:, :]
+            elif total_tokens > 1:
+                maybe_grid = int(round(math.sqrt(total_tokens - 1)))
+                if maybe_grid * maybe_grid == total_tokens - 1:
+                    features = features[:, 1:, :]
+        return features
+
+
+__all__ = ["DualStreamVisionEncoder", "DualStreamVisionOutput"]

--- a/qwen-vl-finetune/qwenvl/models/dual_stream_model.py
+++ b/qwen-vl-finetune/qwenvl/models/dual_stream_model.py
@@ -1,0 +1,268 @@
+"""Integration of the dual-stream encoder and VE-Gate into Qwen2.5-VL."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import torch
+
+from transformers.cache_utils import Cache
+from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
+    Qwen2_5_VLForConditionalGeneration,
+    Qwen2_5_VLModel,
+    Qwen2_5_VLCausalLMOutputWithPast,
+    Qwen2_5_VLModelOutputWithPast,
+)
+from transformers.utils import is_torchdynamo_compiling
+
+from .dual_stream_config import DualStreamConfig
+from .dual_stream_encoder import DualStreamVisionEncoder
+from .ve_gate import VisualEvidenceGate
+
+
+class DualStreamQwen25VLModel(Qwen2_5_VLModel):
+    """Extends :class:`Qwen2_5_VLModel` with dual-stream vision and VE-Gate."""
+
+    def __init__(self, config, dual_stream_config: Optional[DualStreamConfig] = None):
+        self.dual_stream_config = dual_stream_config or DualStreamConfig()
+        super().__init__(config)
+        self.dual_vision = DualStreamVisionEncoder(self.visual, self.dual_stream_config)
+        self.ve_gate = VisualEvidenceGate(
+            hidden_size=self.dual_vision.hidden_size,
+            context_size=self.dual_vision.hidden_size,
+            hidden_ratio=self.dual_stream_config.ve_gate_hidden_ratio,
+            dropout=self.dual_stream_config.ve_gate_dropout,
+            temperature=self.dual_stream_config.ve_gate_temperature,
+        )
+        self.register_to_config(mm_dual_stream=self.dual_stream_config.to_dict())
+        self.last_gating_metadata: Optional[dict] = None
+        self.last_text_mask: Optional[torch.Tensor] = None
+
+    # ------------------------------------------------------------------
+    # Vision feature extraction helpers
+    # ------------------------------------------------------------------
+    def get_image_features(
+        self, pixel_values: torch.FloatTensor, image_grid_thw: Optional[torch.LongTensor] = None
+    ):
+        outputs = self.dual_vision(pixel_values, image_grid_thw=image_grid_thw)
+        return outputs.fused
+
+    def get_dual_stream_features(
+        self, pixel_values: torch.FloatTensor, image_grid_thw: Optional[torch.LongTensor] = None
+    ):
+        """Return raw semantic, high-fidelity and fused tokens for analysis."""
+
+        outputs = self.dual_vision(pixel_values, image_grid_thw=image_grid_thw)
+        return outputs
+
+    # ------------------------------------------------------------------
+    # Forward override with VE-Gate
+    # ------------------------------------------------------------------
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        pixel_values_videos: Optional[torch.FloatTensor] = None,
+        image_grid_thw: Optional[torch.LongTensor] = None,
+        video_grid_thw: Optional[torch.LongTensor] = None,
+        rope_deltas: Optional[torch.LongTensor] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        second_per_grid_ts: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Union[tuple, Qwen2_5_VLModelOutputWithPast]:
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        if inputs_embeds is None:
+            inputs_embeds = self.get_input_embeddings()(input_ids)
+
+        gating_metadata = None
+        image_mask = torch.zeros_like(inputs_embeds, dtype=torch.bool)
+        video_mask_for_text = torch.zeros_like(inputs_embeds, dtype=torch.bool)
+
+        if pixel_values is not None:
+            dual_outputs = self.dual_vision(pixel_values, image_grid_thw=image_grid_thw)
+            fused_tokens = dual_outputs.flatten("fused").to(inputs_embeds.device, inputs_embeds.dtype)
+            semantic_tokens = dual_outputs.flatten("semantic").to(inputs_embeds.device, inputs_embeds.dtype)
+            high_tokens = dual_outputs.flatten("high_fidelity").to(inputs_embeds.device, inputs_embeds.dtype)
+
+            image_mask, video_mask_for_text = self.get_placeholder_mask(
+                input_ids, inputs_embeds=inputs_embeds, image_features=fused_tokens
+            )
+            placeholder_indices = image_mask[..., 0].nonzero(as_tuple=False)
+            if placeholder_indices.shape[0] != fused_tokens.shape[0]:
+                raise ValueError("Mismatch between visual tokens and image placeholders")
+
+            text_context = self._summarise_text_context(inputs_embeds, image_mask, video_mask_for_text)
+            text_tokens = text_context[placeholder_indices[:, 0]]
+
+            original_placeholders = inputs_embeds[placeholder_indices[:, 0], placeholder_indices[:, 1]]
+            gate, gate_logits = self.ve_gate(
+                semantic_tokens, high_tokens, fused_tokens, text_tokens
+            )
+            gated_tokens = gate * fused_tokens + (1.0 - gate) * original_placeholders
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, gated_tokens)
+
+            gating_metadata = {
+                "gate": gate.detach(),
+                "logits": gate_logits.detach(),
+                "indices": placeholder_indices.detach(),
+            }
+
+        if pixel_values_videos is not None:
+            video_embeds = self.get_video_features(pixel_values_videos, video_grid_thw)
+            video_embeds = torch.cat(video_embeds, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
+            _, video_mask = self.get_placeholder_mask(
+                input_ids, inputs_embeds=inputs_embeds, video_features=video_embeds
+            )
+            inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+            video_mask_for_text = video_mask
+
+        if position_ids is None:
+            prefill_compiled_stage = is_torchdynamo_compiling() and (
+                (input_ids is not None and input_ids.shape[1] != 1)
+                or (inputs_embeds is not None and inputs_embeds.shape[1] != 1)
+            )
+            prefill_noncompiled_stage = not is_torchdynamo_compiling() and (
+                (cache_position is not None and cache_position[0] == 0)
+                or (past_key_values is None or past_key_values.get_seq_length() == 0)
+            )
+            if (prefill_compiled_stage or prefill_noncompiled_stage) or self.rope_deltas is None:
+                position_ids, rope_deltas = self.get_rope_index(
+                    input_ids,
+                    image_grid_thw,
+                    video_grid_thw,
+                    second_per_grid_ts=second_per_grid_ts,
+                    attention_mask=attention_mask,
+                )
+                self.rope_deltas = rope_deltas
+            else:
+                batch_size, seq_length, _ = inputs_embeds.shape
+                position_ids = torch.arange(seq_length, device=inputs_embeds.device)
+                position_ids = position_ids.view(1, 1, -1).expand(3, batch_size, -1)
+                if cache_position is not None:
+                    delta = (cache_position[0] + self.rope_deltas).to(inputs_embeds.device)
+                else:
+                    delta = torch.zeros((batch_size, seq_length), device=inputs_embeds.device)
+                delta = delta.repeat_interleave(batch_size // delta.shape[0], dim=1)
+                position_ids = position_ids + delta.to(position_ids.device)
+
+        outputs = self.language_model(
+            input_ids=None,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+        output = Qwen2_5_VLModelOutputWithPast(
+            last_hidden_state=outputs.last_hidden_state,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            rope_deltas=self.rope_deltas,
+        )
+        if gating_metadata is not None:
+            output.visual_evidence = gating_metadata
+        text_mask = (~image_mask[..., 0] & ~video_mask_for_text[..., 0]).detach()
+        output.text_mask = text_mask
+        self.last_gating_metadata = gating_metadata
+        self.last_text_mask = text_mask
+        return output if return_dict else output.to_tuple()
+
+    # ------------------------------------------------------------------
+    # Utility
+    # ------------------------------------------------------------------
+    def _summarise_text_context(
+        self,
+        inputs_embeds: torch.Tensor,
+        image_mask: torch.Tensor,
+        video_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        mask = ~(image_mask[..., 0] | video_mask[..., 0])
+        summaries = []
+        for batch_idx in range(inputs_embeds.shape[0]):
+            valid = mask[batch_idx]
+            if valid.any():
+                summaries.append(inputs_embeds[batch_idx, valid].mean(dim=0))
+            else:
+                summaries.append(inputs_embeds.new_zeros(inputs_embeds.shape[-1]))
+        return torch.stack(summaries, dim=0)
+
+
+class Qwen2_5_VLDualStreamForConditionalGeneration(Qwen2_5_VLForConditionalGeneration):
+    """Drop-in replacement that exposes the dual-stream architecture."""
+
+    def __init__(self, config, dual_stream_config: Optional[DualStreamConfig] = None):
+        self.dual_stream_config = dual_stream_config or DualStreamConfig()
+        super().__init__(config)
+        self.model = DualStreamQwen25VLModel(config, self.dual_stream_config)
+        self.register_to_config(mm_dual_stream=self.dual_stream_config.to_dict())
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        pixel_values_videos: Optional[torch.FloatTensor] = None,
+        image_grid_thw: Optional[torch.LongTensor] = None,
+        video_grid_thw: Optional[torch.LongTensor] = None,
+        rope_deltas: Optional[torch.LongTensor] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        second_per_grid_ts: Optional[torch.Tensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        **kwargs,
+    ) -> Union[tuple, Qwen2_5_VLCausalLMOutputWithPast]:
+        outputs = super().forward(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            rope_deltas=rope_deltas,
+            cache_position=cache_position,
+            second_per_grid_ts=second_per_grid_ts,
+            logits_to_keep=logits_to_keep,
+            **kwargs,
+        )
+        gating_metadata = getattr(self.model, "last_gating_metadata", None)
+        text_mask = getattr(self.model, "last_text_mask", None)
+        if isinstance(outputs, Qwen2_5_VLCausalLMOutputWithPast):
+            outputs.visual_evidence = gating_metadata
+            outputs.text_mask = text_mask
+        return outputs
+
+
+__all__ = ["DualStreamQwen25VLModel", "Qwen2_5_VLDualStreamForConditionalGeneration"]

--- a/qwen-vl-finetune/qwenvl/models/ve_gate.py
+++ b/qwen-vl-finetune/qwenvl/models/ve_gate.py
@@ -1,0 +1,100 @@
+"""Visual evidence gating module for adaptive text-vision fusion."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+
+class VisualEvidenceGate(nn.Module):
+    """Computes a confidence-controlled gate for visual evidence.
+
+    The module compares semantic and high-fidelity visual tokens while
+    conditioning on the textual context. The output gate scales the fused visual
+    representation before it is injected into the language model, reducing the
+    influence of ambiguous or low-confidence visual cues.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        context_size: Optional[int] = None,
+        hidden_ratio: int = 4,
+        dropout: float = 0.1,
+        temperature: float = 1.0,
+    ) -> None:
+        super().__init__()
+        context_size = context_size or hidden_size
+        reduced = max(1, hidden_size // hidden_ratio)
+
+        self.visual_mlp = nn.Sequential(
+            nn.LayerNorm(hidden_size * 3),
+            nn.Linear(hidden_size * 3, hidden_size),
+            nn.SiLU(),
+        )
+        self.context_mlp = nn.Sequential(
+            nn.LayerNorm(context_size),
+            nn.Linear(context_size, hidden_size),
+            nn.SiLU(),
+        )
+        self.gate_head = nn.Sequential(
+            nn.Linear(hidden_size * 2, reduced),
+            nn.SiLU(),
+            nn.Dropout(dropout),
+            nn.Linear(reduced, 1),
+        )
+        self.temperature = nn.Parameter(torch.tensor(float(temperature)))
+
+    def forward(
+        self,
+        semantic_tokens: torch.Tensor,
+        high_fidelity_tokens: torch.Tensor,
+        fused_tokens: torch.Tensor,
+        text_context: torch.Tensor,
+        prior_logits: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Compute gate values for each image placeholder.
+
+        Args:
+            semantic_tokens: Tokens from the original Qwen2.5-VL vision stream.
+            high_fidelity_tokens: Tokens coming from the DINOv3 branch projected
+                into the Qwen embedding space.
+            fused_tokens: Tokens produced after combining both visual streams.
+                They serve as a reference for scaling the final embeddings.
+            text_context: Per-sample textual summaries used to moderate the
+                influence of linguistic priors.
+            prior_logits: Optional prior logits that will be added before the
+                sigmoid, allowing external signals (e.g. heuristic confidence
+                scores) to modulate the gate.
+
+        Returns:
+            gate: Values in ``[0, 1]`` representing how much of the fused visual
+                token should be trusted.
+            logits: Raw logits before the sigmoid activation, useful for
+                monitoring and auxiliary losses.
+        """
+
+        if not (semantic_tokens.shape == high_fidelity_tokens.shape == fused_tokens.shape):
+            raise ValueError("All visual tensors must share the same shape")
+        if text_context.shape != semantic_tokens.shape:
+            raise ValueError("text_context must match the visual token shape")
+
+        visual_features = torch.cat(
+            [semantic_tokens, high_fidelity_tokens, fused_tokens - semantic_tokens], dim=-1
+        )
+        visual_features = self.visual_mlp(visual_features)
+        context_features = self.context_mlp(text_context)
+        gate_input = torch.cat([visual_features, context_features], dim=-1)
+        logits = self.gate_head(gate_input)
+
+        if prior_logits is not None:
+            logits = logits + prior_logits
+
+        temperature = torch.clamp(self.temperature, min=1e-2)
+        gate = torch.sigmoid(logits / temperature)
+        return gate, logits
+
+
+__all__ = ["VisualEvidenceGate"]

--- a/qwen-vl-finetune/qwenvl/train/argument.py
+++ b/qwen-vl-finetune/qwenvl/train/argument.py
@@ -36,3 +36,88 @@ class TrainingArguments(transformers.TrainingArguments):
     )
     mm_projector_lr: Optional[float] = None
     vision_tower_lr: Optional[float] = None
+
+
+@dataclass
+class DualStreamArguments:
+    dinov3_modelscope_model_id: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "ModelScope model identifier or local directory passed to AutoModel.from_pretrained "
+                "to initialise the DINOv3 branch. When set it takes precedence over the torch.hub configuration."
+            )
+        },
+    )
+    dinov3_modelscope_revision: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional revision to load from ModelScope when using a remote checkpoint.",
+        },
+    )
+    dinov3_modelscope_device_map: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Device map forwarded to ModelScope AutoModel for loading the DINOv3 encoder (e.g. 'auto').",
+        },
+    )
+    dinov3_modelscope_trust_remote_code: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to enable trust_remote_code when downloading the DINOv3 checkpoint from ModelScope.",
+        },
+    )
+    dinov3_repo_or_dir: str = field(
+        default="facebookresearch/dinov3",
+        metadata={
+            "help": "Torch Hub repository (or local directory) that provides the DINOv3 implementation."
+        },
+    )
+    dinov3_model_name: str = field(
+        default="dinov3_vith16plus",
+        metadata={
+            "help": "Backbone name resolved by torch.hub.load (e.g. 'dinov3_vith16plus')."
+        },
+    )
+    dinov3_checkpoint_path: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Optional checkpoint path for the DINOv3 backbone. Can be a file "
+                "or directory containing weights such as 'model.safetensors' or "
+                "'pytorch_model.bin'."
+            )
+        },
+    )
+    dinov3_image_size: int = field(
+        default=518,
+        metadata={"help": "Square input resolution for the DINOv3 backbone."},
+    )
+    freeze_semantic_stream: bool = field(
+        default=False,
+        metadata={"help": "Freeze the original Qwen2.5-VL vision tower."},
+    )
+    freeze_high_fidelity_stream: bool = field(
+        default=True,
+        metadata={"help": "Freeze the DINOv3 branch during finetuning."},
+    )
+    fusion_hidden_ratio: float = field(
+        default=2.0,
+        metadata={"help": "Hidden size multiplier used inside the fusion MLP."},
+    )
+    fusion_dropout: float = field(
+        default=0.1,
+        metadata={"help": "Dropout probability applied within the fusion MLP."},
+    )
+    ve_gate_hidden_ratio: int = field(
+        default=4,
+        metadata={"help": "Reduction ratio used by the VE-Gate MLP."},
+    )
+    ve_gate_dropout: float = field(
+        default=0.1,
+        metadata={"help": "Dropout probability inside the VE-Gate."},
+    )
+    ve_gate_temperature: float = field(
+        default=1.0,
+        metadata={"help": "Initial temperature scaling for the VE-Gate sigmoid."},
+    )

--- a/qwen-vl-finetune/qwenvl/train/test_dual_stream.py
+++ b/qwen-vl-finetune/qwenvl/train/test_dual_stream.py
@@ -1,0 +1,147 @@
+"""Evaluate Qwen2.5-VL with or without the dual-stream enhancements."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import torch
+from PIL import Image
+from tqdm import tqdm
+from transformers import (
+    AutoProcessor,
+    Qwen2_5_VLForConditionalGeneration,
+)
+
+from qwenvl.models import Qwen2_5_VLDualStreamForConditionalGeneration
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_name_or_path", type=str, required=True)
+    parser.add_argument("--data_file", type=str, required=True, help="JSON/JSONL annotations")
+    parser.add_argument(
+        "--output_file", type=str, default=None, help="Optional path to dump per-sample predictions"
+    )
+    parser.add_argument("--max_new_tokens", type=int, default=64)
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument(
+        "--baseline",
+        action="store_true",
+        help="Use the original Qwen2.5-VL model without the dual-stream modules.",
+    )
+    parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--max_samples", type=int, default=None)
+    return parser.parse_args()
+
+
+def load_dataset(path: Path) -> List[Dict[str, Any]]:
+    samples: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fp:
+        if path.suffix.lower() in {".jsonl", ".jsonl.gz"}:
+            for line in fp:
+                if not line.strip():
+                    continue
+                samples.append(json.loads(line))
+        else:
+            data = json.load(fp)
+            if isinstance(data, list):
+                samples = data
+            else:
+                raise ValueError("Expected a list of samples in the dataset file")
+    return samples
+
+
+def normalise_text(text: str) -> str:
+    return " ".join(text.strip().lower().split())
+
+
+def run_evaluation(args: argparse.Namespace) -> None:
+    path = Path(args.data_file)
+    data = load_dataset(path)
+    if args.max_samples is not None:
+        data = data[: args.max_samples]
+
+    processor = AutoProcessor.from_pretrained(args.model_name_or_path)
+    if args.baseline:
+        model = Qwen2_5_VLForConditionalGeneration.from_pretrained(args.model_name_or_path)
+    else:
+        model = Qwen2_5_VLDualStreamForConditionalGeneration.from_pretrained(args.model_name_or_path)
+    model.to(args.device)
+    model.eval()
+
+    results: List[Dict[str, Any]] = []
+    correct = 0
+
+    for sample in tqdm(data, desc="evaluating"):
+        image = Image.open(sample["image"]).convert("RGB")
+        question = sample["question"].strip()
+        answer = normalise_text(sample["answer"])
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": question},
+                ],
+            }
+        ]
+        prompt = processor.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        inputs = processor(
+            text=[prompt], images=[image], return_tensors="pt", padding=True
+        ).to(args.device)
+
+        with torch.inference_mode():
+            generated = model.generate(
+                **inputs,
+                max_new_tokens=args.max_new_tokens,
+                do_sample=False,
+                pad_token_id=processor.tokenizer.eos_token_id,
+            )
+
+        output_ids = generated[:, inputs["input_ids"].shape[-1] :]
+        prediction = processor.tokenizer.batch_decode(
+            output_ids, skip_special_tokens=True, clean_up_tokenization_spaces=True
+        )[0]
+        prediction_norm = normalise_text(prediction)
+        is_correct = prediction_norm == answer
+        correct += int(is_correct)
+
+        gate_stats = None
+        if hasattr(model, "model") and getattr(model.model, "last_gating_metadata", None):
+            metadata = model.model.last_gating_metadata or {}
+            gate_values = metadata.get("gate")
+            if gate_values is not None and gate_values.numel() > 0:
+                gate_values = gate_values.squeeze(-1).cpu()
+                gate_stats = {
+                    "mean": gate_values.mean().item(),
+                    "min": gate_values.min().item(),
+                    "max": gate_values.max().item(),
+                }
+
+        results.append(
+            {
+                "question": question,
+                "answer": sample["answer"],
+                "prediction": prediction.strip(),
+                "correct": bool(is_correct),
+                "gate_stats": gate_stats,
+            }
+        )
+
+    accuracy = correct / max(1, len(results))
+    print(f"Accuracy: {accuracy * 100:.2f}% ({correct}/{len(results)})")
+
+    if args.output_file:
+        out_path = Path(args.output_file)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as fp:
+            for item in results:
+                fp.write(json.dumps(item, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    run_evaluation(parse_args())

--- a/qwen-vl-finetune/qwenvl/train/train_dual_stream.py
+++ b/qwen-vl-finetune/qwenvl/train/train_dual_stream.py
@@ -1,0 +1,186 @@
+"""Training entry-point for the dual-stream + VE-Gate Qwen2.5-VL model."""
+
+import logging
+import os
+import pathlib
+from pathlib import Path
+
+import torch
+import transformers
+
+project_root = Path(__file__).parent.parent.parent
+import sys
+
+sys.path.append(str(project_root))
+
+from qwenvl.data.data_qwen import make_supervised_data_module
+from qwenvl.data.data_qwen_packed import make_supervised_data_module_packed
+from qwenvl.models import DualStreamConfig, Qwen2_5_VLDualStreamForConditionalGeneration
+from qwenvl.train.argument import (
+    DataArguments,
+    DualStreamArguments,
+    ModelArguments,
+    TrainingArguments,
+)
+from qwenvl.train.trainer import replace_qwen2_vl_attention_class
+
+local_rank = None
+
+
+def rank0_print(*args):
+    if local_rank == 0:
+        print(*args)
+
+
+def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: str):
+    if trainer.deepspeed:
+        torch.cuda.synchronize()
+        trainer.save_model(output_dir)
+        return
+
+    state_dict = trainer.model.state_dict()
+    if trainer.args.should_save:
+        cpu_state_dict = {key: value.cpu() for key, value in state_dict.items()}
+        del state_dict
+        trainer._save(output_dir, state_dict=cpu_state_dict)
+
+
+def build_dual_stream_config(args: DualStreamArguments) -> DualStreamConfig:
+    return DualStreamConfig(
+        dinov3_modelscope_model_id=args.dinov3_modelscope_model_id,
+        dinov3_modelscope_revision=args.dinov3_modelscope_revision,
+        dinov3_modelscope_device_map=args.dinov3_modelscope_device_map,
+        dinov3_modelscope_trust_remote_code=args.dinov3_modelscope_trust_remote_code,
+        dinov3_repo_or_dir=args.dinov3_repo_or_dir,
+        dinov3_model_name=args.dinov3_model_name,
+        dinov3_checkpoint_path=args.dinov3_checkpoint_path,
+        dinov3_image_size=args.dinov3_image_size,
+        freeze_semantic_stream=args.freeze_semantic_stream,
+        freeze_high_fidelity_stream=args.freeze_high_fidelity_stream,
+        fusion_hidden_ratio=args.fusion_hidden_ratio,
+        fusion_dropout=args.fusion_dropout,
+        ve_gate_hidden_ratio=args.ve_gate_hidden_ratio,
+        ve_gate_dropout=args.ve_gate_dropout,
+        ve_gate_temperature=args.ve_gate_temperature,
+    )
+
+
+def set_trainable_params(model_args: ModelArguments, model: Qwen2_5_VLDualStreamForConditionalGeneration):
+    dual = model.model.dual_vision
+
+    if model_args.tune_mm_vision:
+        for param in dual.semantic_encoder.parameters():
+            param.requires_grad = True
+        for param in dual.high_fidelity_encoder.parameters():
+            param.requires_grad = True
+    else:
+        for param in dual.semantic_encoder.parameters():
+            param.requires_grad = False
+        for param in dual.high_fidelity_encoder.parameters():
+            param.requires_grad = False
+
+    if model_args.tune_mm_mlp:
+        for param in dual.high_proj.parameters():
+            param.requires_grad = True
+        for param in dual.fusion_mlp.parameters():
+            param.requires_grad = True
+        model.model.ve_gate.requires_grad_(True)
+    else:
+        for param in dual.high_proj.parameters():
+            param.requires_grad = False
+        for param in dual.fusion_mlp.parameters():
+            param.requires_grad = False
+        model.model.ve_gate.requires_grad_(False)
+
+    if model_args.tune_mm_llm:
+        for param in model.model.language_model.parameters():
+            param.requires_grad = True
+        model.lm_head.requires_grad = True
+    else:
+        for param in model.model.language_model.parameters():
+            param.requires_grad = False
+        model.lm_head.requires_grad = False
+
+
+def log_trainable_parameters(model: torch.nn.Module):
+    total = sum(p.numel() for p in model.parameters())
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    rank0_print(f"Trainable parameters: {trainable / 1e6:.2f}M / {total / 1e6:.2f}M")
+
+
+def train(attn_implementation: str = "flash_attention_2"):
+    global local_rank
+
+    parser = transformers.HfArgumentParser(
+        (ModelArguments, DataArguments, TrainingArguments, DualStreamArguments)
+    )
+    model_args, data_args, training_args, dual_args = parser.parse_args_into_dataclasses()
+
+    local_rank = training_args.local_rank
+    os.makedirs(training_args.output_dir, exist_ok=True)
+
+    dual_config = build_dual_stream_config(dual_args)
+
+    model = Qwen2_5_VLDualStreamForConditionalGeneration.from_pretrained(
+        model_args.model_name_or_path,
+        cache_dir=training_args.cache_dir,
+        attn_implementation=attn_implementation,
+        torch_dtype=(torch.bfloat16 if training_args.bf16 else None),
+        dual_stream_config=dual_config,
+    )
+    processor = transformers.AutoProcessor.from_pretrained(model_args.model_name_or_path)
+    data_args.image_processor = processor.image_processor
+    data_args.model_type = "qwen2.5vl"
+
+    if data_args.data_flatten:
+        replace_qwen2_vl_attention_class()
+    model.config.use_cache = False
+
+    if training_args.gradient_checkpointing:
+        if hasattr(model, "enable_input_require_grads"):
+            model.enable_input_require_grads()
+        else:
+            def make_inputs_require_grad(module, inputs, output):
+                output.requires_grad_(True)
+
+            model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        model_args.model_name_or_path,
+        cache_dir=training_args.cache_dir,
+        model_max_length=training_args.model_max_length,
+        padding_side="right",
+        use_fast=False,
+    )
+
+    set_trainable_params(model_args, model)
+    log_trainable_parameters(model)
+
+    if data_args.data_packing:
+        data_module = make_supervised_data_module_packed(tokenizer=tokenizer, data_args=data_args)
+    else:
+        data_module = make_supervised_data_module(tokenizer=tokenizer, data_args=data_args)
+
+    trainer = transformers.Trainer(
+        model=model,
+        args=training_args,
+        processing_class=tokenizer,
+        **data_module,
+    )
+
+    checkpoints = list(pathlib.Path(training_args.output_dir).glob("checkpoint-*"))
+    if checkpoints:
+        logging.info("checkpoint found, resume training")
+        trainer.train(resume_from_checkpoint=True)
+    else:
+        trainer.train()
+
+    trainer.save_state()
+    processor.save_pretrained(training_args.output_dir)
+
+    model.config.use_cache = True
+    safe_save_model_for_hf_trainer(trainer=trainer, output_dir=training_args.output_dir)
+
+
+if __name__ == "__main__":
+    train(attn_implementation="flash_attention_2")


### PR DESCRIPTION
## Summary
- add ModelScope-backed configuration knobs to the dual-stream setup and prefer them before torch.hub
- extend the dual-stream encoder to unwrap ModelScope modules, handle diverse output formats and gracefully fall back to torch.hub/timm
- document the new CLI options so local ModelScope checkpoints can be wired into the training pipeline

## Testing
- python -m compileall qwen-vl-finetune/qwenvl/models qwen-vl-finetune/qwenvl/train/train_dual_stream.py qwen-vl-finetune/qwenvl/train/test_dual_stream.py

------
https://chatgpt.com/codex/tasks/task_e_68ca28cb90d4832990cd05c7ddb265fb